### PR TITLE
chore: Removing unused endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.4
 * Adding iOS support
 * Public API is documented
+* `platformVersion` example method has been removed
 
 ## 0.1.3
 * Android V2 embedding

--- a/lib/bluetooth_enable_fork.dart
+++ b/lib/bluetooth_enable_fork.dart
@@ -5,11 +5,6 @@ import 'package:flutter/services.dart';
 class BluetoothEnable {
   static const MethodChannel _channel = const MethodChannel('bluetooth_enable');
 
-  static Future<String> get platformVersion async {
-    final String version = await _channel.invokeMethod('getPlatformVersion');
-    return version;
-  }
-
   /// Main method of this package.
   ///
   /// This will check if Bluetooth is enabled on the smartphone; if it's not the

--- a/test/bluetooth_enable_test.dart
+++ b/test/bluetooth_enable_test.dart
@@ -9,7 +9,7 @@ void main() {
 
   setUp(() {
     channel.setMockMethodCallHandler((MethodCall methodCall) async {
-      return '42';
+      return 'true';
     });
   });
 
@@ -17,7 +17,7 @@ void main() {
     channel.setMockMethodCallHandler(null);
   });
 
-  test('getPlatformVersion', () async {
-    expect(await BluetoothEnable.platformVersion, '42');
+  test('getEnableBluetoothResult', () async {
+    expect(await BluetoothEnable.enableBluetooth, 'true');
   });
 }


### PR DESCRIPTION
`platformVersion` method is an example method that illustrates how the method channel works; we don't need it in this package.